### PR TITLE
Removed #ship-it option

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Please include a summary of the change along with the reasoning and/or motivatio
 
 - [ ] 🧪 Ensure you have written tests
 - [ ] 🧑‍🔬 Test your code in the appropriate environment (i.e development/staging/production)
-- [ ] 🗨️ Inform PM when merged if the change is relevant for the rest of the company
+- [ ] 🗨️ Inform PM when PR is merged if the change is relevant to the rest of the company
 
 ## Reference
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Please include a summary of the change along with the reasoning and/or motivatio
 
 - [ ] 🧪 Ensure you have written tests
 - [ ] 🧑‍🔬 Test your code in the appropriate environment (i.e development/staging/production)
+- [ ] 🗨️ Inform PM when merged if the change is relevant for the rest of the company
 
 ## Reference
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@ required and any potential issues to look out for.
 
 - [ ] 🧪 Ensure you have written tests
 - [ ] 🧑‍🔬 Test your code in the appropriate environment (i.e development/staging/production)
-- [ ] :shipit: Post an update in #ship-it 
 
 ## Reference
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,12 @@
 ## Context/Change
 
-Please include a summary of the change along with the reasoning and/or motivation behind it. List any dependencies that are
-required and any potential issues to look out for.
+Please include a summary of the change along with the reasoning and/or motivation behind it. List any dependencies that are required and any potential issues to look out for.
 
-### Checklist
+## Checklist
 
 - [ ] 🧪 Ensure you have written tests
 - [ ] 🧑‍🔬 Test your code in the appropriate environment (i.e development/staging/production)
 
 ## Reference
 
-Linear will automatically add a reference to the issue if you use the name of the ticket as the branch
+Linear will automatically add a reference to the issue if you use the name of the ticket as the branch.


### PR DESCRIPTION
Most of the changes don't require them and if a #shipit post is required, it should go through PMs first.